### PR TITLE
adding relay port

### DIFF
--- a/packages/hypertunnel/cli.js
+++ b/packages/hypertunnel/cli.js
@@ -16,6 +16,7 @@ module.exports = async (argv) => {
     .option('-s, --server [server]', 'hypertunnel server to use', 'https://hypertunnel.ga')
     .option('-t, --token [token]', 'token required by the server', 'free-server-please-be-nice')
     .option('-i, --internet-port [port]', 'the desired internet port on the public server', parseInt)
+    .option('-r, --relay-port [port]', 'the desired relay port on the public server', parseInt)
     .option('--ssl', 'enable SSL termination (https://) on the public server')
     .parse(argv)
 
@@ -41,7 +42,8 @@ module.exports = async (argv) => {
     host: program.localhost,
     server: program.server,
     token: program.token,
-    internetPort: program.internetPort
+    internetPort: program.internetPort,
+    relayPort: program.relayPort
   }, { ssl: program.ssl })
   await client.create()
   let message = `

--- a/packages/hypertunnel/lib/Client.js
+++ b/packages/hypertunnel/lib/Client.js
@@ -22,7 +22,7 @@ class Client {
     this.deleted = false
     this.relay = null
     this.internetPort = null
-    this.relayPort = null
+    this.relayPort = opts.relayPort || null
     this.uri = null
     this.secret = null
     this.createdAt = null
@@ -36,6 +36,7 @@ class Client {
     const payload = {
       serverToken: this.token,
       internetPort: this.desiredInternetPort,
+      relayPort: this.relayPort,
       ssl: this.options.ssl
     }
     debug('create payload', payload)

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,8 @@ This free TCP relay/reverse proxy service can be used to **expose any TCP/IP ser
     -s, --server [server]        hypertunnel server to use (default: https://hypertunnel.ga)
     -t, --token [token]          token required by the server (default: free-server-please-be-nice)
     -i, --internet-port [port]   the desired internet port on the public server
-    --ssl                        enable SSL termination (https://) on the public server    
+    -r, --relay-port [port]      the desired relay port on the public server
+    --ssl                        enable SSL termination (https://) on the public server
     -h, --help                   output usage information
 ```
 
@@ -169,7 +170,7 @@ Enter username: You are now bob
 
 ## Comparison to localtunnel/ngrok
 
-Both are great services! 
+Both are great services!
 If your use-case is to simply tunnel local http web server traffic I suggest using them. :-)
 
 I ran into issues when trying to expose a local proxy server (to use the client as forwarding proxy). Both services need to inspect and rewrite HTTP headers for routing, so using the tunnel as a proxy in e.g. Chrome won't work. There are a couple other use-cases where raw TCP stream tunnelling is desired and hypertunnel is the only available option.
@@ -207,7 +208,7 @@ Given that there is no alternative to hypertunnel I figured I'd rather release i
 
 ## Contributing
 
-Contributions are welcome. 
+Contributions are welcome.
 
 We use a [monorepo](https://github.com/berstend/hypertunnel) powered by [Lerna](https://github.com/lerna/lerna#--use-workspaces) (and yarn workspaces), [ava](https://github.com/avajs/ava) for testing and the [standard](https://standardjs.com/) style for linting.
 
@@ -218,7 +219,7 @@ We use a [monorepo](https://github.com/berstend/hypertunnel) powered by [Lerna](
 # Make sure you have a recent version of yarn & lerna installed:
 npm install -g yarn lerna
 
-# Bootstrap the packages in the current Lerna repo. 
+# Bootstrap the packages in the current Lerna repo.
 # Installs all of their dependencies and links any cross-dependencies.
 yarn bootstrap
 


### PR DESCRIPTION
Currently, the relay port is always random. This doesn't work well if the server is dockerized. It needs to know which ports to forward when the server starts. It looks like the server already takes in relay port, but the client is just never sending it. 

This PR adds a `-r`, `--relay-port` option to the client CLI. If the option is set, that port will be sent to the server and used as the relay port.